### PR TITLE
cgo=0, change to multistage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,14 @@
-FROM alpine:latest
-MAINTAINER Jessica Frazelle <jess@linux.com>
+# Builder image
+FROM golang:alpine AS builder
+WORKDIR /go/src/github.com/jessfraz/sshb0t
+COPY . .
+RUN GOOS=linux CGO_ENABLED=0 go build -o sshb0t
 
-ENV PATH /go/bin:/usr/local/go/bin:$PATH
-ENV GOPATH /go
-
+# Final image
+FROM alpine
+LABEL maintainer "Jessica Frazelle <jess@linux.com>"
 RUN	apk add --no-cache \
-	ca-certificates
-
-COPY . /go/src/github.com/jessfraz/sshb0t
-
-RUN set -x \
-	&& apk add --no-cache --virtual .build-deps \
-		go \
-		git \
-		gcc \
-		libc-dev \
-		libgcc \
-	&& cd /go/src/github.com/jessfraz/sshb0t \
-	&& go build -o /usr/bin/sshb0t . \
-	&& apk del .build-deps \
-	&& rm -rf /go \
-	&& echo "Build complete."
-
-
-ENTRYPOINT [ "sshb0t" ]
+    ca-certificates \
+    git
+COPY --from=builder /go/src/github.com/jessfraz/sshb0t/sshb0t /usr/bin/sshb0t
+ENTRYPOINT ["sshb0t"]


### PR DESCRIPTION
Hey Jess,

nice tool 👍 

i changed the Dockerfile to make use of the multistage build introduced in 17.05
https://docs.docker.com/engine/userguide/eng-image/multistage-build/

The later image contains only the binary, git and the certificates.

Is there a reason why we need libgcc which is not covered by using CGO_ENABLED=0 ?
(because i am not really sure, if did fuck up with the change :) )
It works AFAIK (tested with docker run without arguments)
<img width="635" alt="screen shot 2017-11-15 at 01 20 17" src="https://user-images.githubusercontent.com/18464684/32812022-325dc626-c9a3-11e7-8960-c407c5113cd0.png">




