### PR TITLE
Add support for ignoring keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,12 +47,13 @@ Usage: sshb0t <command>
 
 Flags:
 
-  --url       GitHub Enterprise URL (default: https://github.com)
-  --user      GitHub usernames for which to fetch keys (default: [])
   -d          enable debug logging (default: false)
+  --ignore    ignore SSH keys that match (default: [])
   --interval  update interval (ex. 5ms, 10s, 1m, 3h) (default: 30s)
   --keyfile   file to update the authorized_keys (default: /home/jessie/.ssh/authorized_keys)
   --once      run once and exit, do not run as a daemon (default: false)
+  --url       GitHub Enterprise URL (default: https://github.com)
+  --user      GitHub usernames for which to fetch keys (default: [])
 
 Commands:
 


### PR DESCRIPTION
Hi,

I wanted to exclude one key from GitHub that I don't use for remote server SSH, here's a simple implementation that does string matching on a per-line basis.

This would allow `--ignore ssh-ed25519` to ignore all ed25519 keys (for whatever reason 🙄) and `--ignore "ssh-ed25519 AAAA...."` to ignore a specific key.

Let me know if it's not a good fit or you want me to change something 😄.