### PR TITLE
Don't write file if no keys were retrieved

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 sudo: false
 go:
-  - 1.10.x
+  - 1.12.x
 before_install:
   - go get golang.org/x/lint/golint
   - go get honnef.co/go/tools/cmd/staticcheck

--- a/main.go
+++ b/main.go
@@ -166,7 +166,8 @@ func run() {
 	}
 
 	if successes < 1 {
-		logrus.Fatalf("Unable to fetch any user keys, aborting")
+		logrus.Warnf("Unable to fetch any user keys, not updating authorized keys file")
+		return
 	}
 
 	// update the authorized key file

--- a/main.go
+++ b/main.go
@@ -131,7 +131,10 @@ func main() {
 
 func run() {
 	// fetch the keys for each user
-	var keys string
+	var (
+		keys      string
+		successes int
+	)
 	for _, user := range users {
 		// fetch the url
 		uri := fmt.Sprintf(defaultKeyURI, enturl, user)
@@ -159,6 +162,11 @@ func run() {
 		}
 		// append to keys variable with a new line
 		keys += string(b)
+		successes++
+	}
+
+	if successes < 1 {
+		logrus.Fatalf("Unable to fetch any user keys, aborting")
 	}
 
 	// update the authorized key file


### PR DESCRIPTION
I ran into a bug when running sshb0t which this PR fixes. The issue happened when the host that was running it had a DNS issue and couldn't reach github.com. When something like that happens, it will still write the authorized keys file except it will be blank. This change ensures that at least one user key was successfully fetched before updating the file.

Also updated the Travis config to use Go 1.12 since `honnef.co/go/tools/cmd/staticcheck` no longer supports 1.10.